### PR TITLE
크래프팅 UI 개선 ( 보유 수량 추가 및 색 추가 ) / 컷씬 페이드인아웃 개선 및 메시지 색상 변경

### DIFF
--- a/ReBloom/Assets/LiveScriptReload/Plugins/LiteNetLib/LiteNetLib.csproj.meta
+++ b/ReBloom/Assets/LiveScriptReload/Plugins/LiteNetLib/LiteNetLib.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d2c7d9a327b1d914a9397c9d08e1dd56
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ReBloom/Assets/Prefabs/ScenePrefabs/CraftSystemBoot.prefab
+++ b/ReBloom/Assets/Prefabs/ScenePrefabs/CraftSystemBoot.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 10, y: -88}
-  m_SizeDelta: {x: 200, y: 50}
+  m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5109058550801271709
 CanvasRenderer:
@@ -2182,7 +2182,7 @@ MonoBehaviour:
   craftButton: {fileID: 7150017228346516361}
   recipeNameText: {fileID: 3502954738239289853}
   recipeDescText: {fileID: 7289302657812158288}
-  recipeMaterialsText: {fileID: 3464292795377997197}
+  recipeMaterialsText: {fileID: 5274684749410480869}
   recipeResultText: {fileID: 4520597095733271331}
   slotParent: {fileID: 6773121995959363321}
   slotPrefab: {fileID: 7324161223378419626, guid: 5c6ed0b96546abf4fa13619fe1f4b263, type: 3}
@@ -2762,6 +2762,142 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8135970081474377603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3321519403497287224}
+  - component: {fileID: 1654661798785464081}
+  - component: {fileID: 5274684749410480869}
+  m_Layer: 0
+  m_Name: Text (TMP) (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3321519403497287224
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8135970081474377603}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6384603877262051397}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 12.5, y: -117}
+  m_SizeDelta: {x: 195, y: 180}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1654661798785464081
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8135970081474377603}
+  m_CullTransparentMesh: 1
+--- !u!114 &5274684749410480869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8135970081474377603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC544\uC774\uD0EC \uC7AC\uB8CC"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: fe78cff6f02b215428f8ebb7422110bd, type: 2}
+  m_sharedMaterial: {fileID: -4295705320344076477, guid: fe78cff6f02b215428f8ebb7422110bd, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8476354082324833668
 GameObject:
   m_ObjectHideFlags: 0
@@ -2967,6 +3103,7 @@ RectTransform:
   - {fileID: 7038514251920457254}
   - {fileID: 5765273324647042983}
   - {fileID: 2695852628169906820}
+  - {fileID: 3321519403497287224}
   - {fileID: 2610331345794512048}
   - {fileID: 6036736289170059957}
   - {fileID: 1507030036684097865}

--- a/ReBloom/Assets/Prefabs/UiPrefabs/DialogueCanvas.prefab
+++ b/ReBloom/Assets/Prefabs/UiPrefabs/DialogueCanvas.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uC2A4\uD0B5 [SPACE]"
+  m_text: "\uAFB9 \uB20C\uB7EC\uC11C \uC2A4\uD0B5 [SPACE]"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: fe78cff6f02b215428f8ebb7422110bd, type: 2}
   m_sharedMaterial: {fileID: -4295705320344076477, guid: fe78cff6f02b215428f8ebb7422110bd, type: 2}
@@ -170,8 +170,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -255, y: 97}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: -282.7, y: 120}
+  m_SizeDelta: {x: 150, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1979618659219877577
 CanvasRenderer:
@@ -245,7 +245,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -43}
+  m_AnchoredPosition: {x: -21, y: -43}
   m_SizeDelta: {x: -100, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7413288946430140931
@@ -372,17 +372,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3992028065129480385}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1362330052437321810}
+  m_Father: {fileID: 1846331094093234011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 801.6892, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &12878552144830709
 CanvasRenderer:
@@ -434,6 +434,7 @@ GameObject:
   - component: {fileID: 741880270115465687}
   - component: {fileID: 8173814261896868589}
   - component: {fileID: 7169588346689615860}
+  - component: {fileID: 2992124958171627376}
   m_Layer: 5
   m_Name: DialoguePanel
   m_TagString: Untagged
@@ -448,7 +449,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4517910534388884847}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -456,12 +457,12 @@ RectTransform:
   - {fileID: 3972443039724972028}
   - {fileID: 5320606892896436318}
   - {fileID: 8512762122882008476}
-  m_Father: {fileID: 1362330052437321810}
+  m_Father: {fileID: 1846331094093234011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -148.89886}
-  m_SizeDelta: {x: 0, y: -297.7977}
+  m_SizeDelta: {x: 801.6892, y: 302.2023}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &741880270115465687
 CanvasRenderer:
@@ -519,7 +520,21 @@ MonoBehaviour:
   root: {fileID: 4517910534388884847}
   messageText: {fileID: 6439406186898231815}
   characterImage: {fileID: 3244378739849720669}
+  backgroundImage: {fileID: 5577737273405749052}
   typeSpeed: 40
+  fadeDuration: 0.25
+--- !u!225 &2992124958171627376
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4517910534388884847}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &5773327620938422264
 GameObject:
   m_ObjectHideFlags: 0
@@ -555,7 +570,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -22.379}
-  m_SizeDelta: {x: 50, y: 7.4119}
+  m_SizeDelta: {x: 95, y: 7.4119}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4130632968935974793
 CanvasRenderer:
@@ -595,6 +610,56 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7333997205384290968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1846331094093234011}
+  - component: {fileID: 6865695992299619275}
+  m_Layer: 5
+  m_Name: DialogueRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1846331094093234011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7333997205384290968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5027494324389708967}
+  - {fileID: 9122087592524575887}
+  m_Father: {fileID: 1362330052437321810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &6865695992299619275
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7333997205384290968}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &7454756938500135222
 GameObject:
   m_ObjectHideFlags: 0
@@ -607,7 +672,6 @@ GameObject:
   - component: {fileID: 4108745159385660299}
   - component: {fileID: 4340526675565778670}
   - component: {fileID: 4300542841750780400}
-  - component: {fileID: 4617576583958069629}
   m_Layer: 5
   m_Name: DialogueCanvas
   m_TagString: Untagged
@@ -628,8 +692,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3119262590430574025}
-  - {fileID: 5027494324389708967}
-  - {fileID: 9122087592524575887}
+  - {fileID: 1846331094093234011}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -700,18 +763,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!225 &4617576583958069629
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7454756938500135222}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
 --- !u!1 &7927887995128837066
 GameObject:
   m_ObjectHideFlags: 0
@@ -748,7 +799,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -238, y: 75.8}
+  m_AnchoredPosition: {x: -261.2, y: 89}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1526420939327372301
@@ -923,14 +974,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.38431373}
+  m_Color: {r: 0.509434, g: 0.509434, b: 0.509434, a: 0.60784316}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e8d0f5f5f9cad4d7a9ab9ca87c52f10a, type: 3}
+  m_Sprite: {fileID: 21300000, guid: e47621b43d1634d0c8165dbedd08aea9, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/ReBloom/Assets/Scenes/MainScene.unity
+++ b/ReBloom/Assets/Scenes/MainScene.unity
@@ -292,17 +292,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: 59bf6f93a384f9e41b45c36fa65e247f, type: 3}
   m_PrefabInstance: {fileID: 1068744568}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &302170613 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-  m_PrefabInstance: {fileID: 3071402431937619815}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!134 &323962727
 PhysicsMaterial:
   m_ObjectHideFlags: 0
@@ -1601,6 +1590,7 @@ MonoBehaviour:
   cutSceneImage: {fileID: 3071402431937619819}
   backgroundImage: {fileID: 3071402431937619818}
   cutSceneGroup: {fileID: 3071402431937619817}
+  skipHoldUI: {fileID: 3071402431937619821}
   introCutSceneId: 1
   seenKeyPrefix: CutScene_
   fadeDuration: 0.5
@@ -3303,73 +3293,9 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2692577772589344599, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972443039724972028, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972443039724972028, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972443039724972028, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -282.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 3972443039724972028, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 120
-      objectReference: {fileID: 0}
-    - target: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e47621b43d1634d0c8165dbedd08aea9, type: 3}
-    - target: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_Color.a
-      value: 0.60784316
-      objectReference: {fileID: 0}
-    - target: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_Color.b
-      value: 0.509434
-      objectReference: {fileID: 0}
-    - target: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_Color.g
-      value: 0.509434
-      objectReference: {fileID: 0}
-    - target: {fileID: 5577737273405749052, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_Color.r
-      value: 0.509434
-      objectReference: {fileID: 0}
-    - target: {fileID: 5664524007324304387, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 95
-      objectReference: {fileID: 0}
-    - target: {fileID: 7169588346689615860, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: backgroundImage
-      value: 
-      objectReference: {fileID: 302170613}
     - target: {fileID: 7454756938500135222, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
       propertyPath: m_Name
       value: DialogueCanvas
-      objectReference: {fileID: 0}
-    - target: {fileID: 8366023380383808408, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -21
-      objectReference: {fileID: 0}
-    - target: {fileID: 8512762122882008476, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -261.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8512762122882008476, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 89
-      objectReference: {fileID: 0}
-    - target: {fileID: 8637922869318930102, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
-      propertyPath: m_text
-      value: "\uAFB9 \uB20C\uB7EC\uC11C \uC2A4\uD0B5 [SPACE]"
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -3389,7 +3315,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!225 &3071402431937619817 stripped
 CanvasGroup:
-  m_CorrespondingSourceObject: {fileID: 4617576583958069629, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6865695992299619275, guid: 334112ed8d703c347a8da67fd011b66e, type: 3}
   m_PrefabInstance: {fileID: 3071402431937619815}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &3071402431937619818 stripped

--- a/ReBloom/Assets/Scripts/Craft/UI/CraftingUI.cs
+++ b/ReBloom/Assets/Scripts/Craft/UI/CraftingUI.cs
@@ -55,6 +55,7 @@ public class CraftingUI : UIBase
     {
         selectedAmount = Mathf.RoundToInt(value);
         UpdateCraftCountText();
+        RefreshMaterialText();
     }
 
     private void UpdateCraftCountText()
@@ -96,10 +97,11 @@ public class CraftingUI : UIBase
             });
     }
 
+    private CraftingSlotUI firstslot;
+
     private void Start()
     {
         var recipes = recipeDb.GetAll();
-        CraftingSlotUI firstslot = null;
         foreach (var recipe in recipes)
         {
             var slot = Instantiate(slotPrefab, slotParent);
@@ -110,11 +112,22 @@ public class CraftingUI : UIBase
         firstslot?.Select();
     }
 
+    private void OnEnable()
+    {
+        firstslot?.Select();
+    }
+
     public void OnClickCraftButton()
     {
-        if (selectedAmount <= 0)
+        if (selectedAmount <= 0 && maxCraftable > 0)
         {
             setResultText("제작 수량을 선택해주세요.");
+            return;
+        }
+
+        if (selectedAmount <= 0)
+        {
+            setResultText("재료가 부족합니다.");
             return;
         }
 
@@ -160,6 +173,7 @@ public class CraftingUI : UIBase
                 craftingCountSlider.value = selectedAmount;
             }
             UpdateCraftCountText();
+            RefreshMaterialText();
         }
     }
 
@@ -167,6 +181,18 @@ public class CraftingUI : UIBase
     {
         recipeResultText.text = result;
     }
+
+    private void RefreshMaterialText()
+    {
+        if (!recipeDb.TryGet(currentRecipeId, out var recipe))
+            return;
+
+        int amount = Mathf.Max(selectedAmount, 1); // 0이면 그냥 1개 기준으로 보여주게
+
+        var check = crafting.CanCraft(currentRecipeId, amount);
+        recipeMaterialsText.text = BuildMaterialText(recipe, check, amount);
+    }
+
 
     public void SelectRecipe(int recipeId)
     {
@@ -177,7 +203,6 @@ public class CraftingUI : UIBase
             return;
 
         recipeNameText.text = recipe.productName;  
-        recipeMaterialsText.text = BuildMaterialText(recipe); 
         recipeResultText.text = string.Empty;
 
         maxCraftable = crafting.GetMaxCraftable(recipeId);
@@ -193,19 +218,47 @@ public class CraftingUI : UIBase
         }
 
         UpdateCraftCountText();
+        RefreshMaterialText();
     }
 
-    private string BuildMaterialText(CraftRecipeData recipe)
+    private string BuildMaterialText(
+        CraftRecipeData recipe,
+        CraftCheckResult check,
+        int amount)
     {
         System.Text.StringBuilder sb = new System.Text.StringBuilder();
-        sb.AppendLine("필요 재료 : ");
+
         foreach (var mat in recipe.materials)
         {
-            var itemName = mat.name;
-            sb.AppendLine($"{itemName} x{mat.count}");
+            int need = mat.count * amount;
+
+            check.missingMaterials?.TryGetValue(mat.itemId, out int missing);
+
+            int owned = inventory.GetItemCount(mat.itemId);
+            bool isLack = owned < need;
+            int lack = System.Math.Max(0, need - owned);
+
+            //if (isLack) sb.Append("<color=#ff8080>");   // 빨간색 계열
+            //else        sb.Append("<color=#80ff80>");   // 초록색 계열
+
+            //sb.Append($"{mat.name} (보유: {owned} / <color=#A0A0A0>소모: {need}");
+
+            // if (isLack)
+            //     sb.Append($", 부족: {lack}");
+            if (isLack) sb.Append("<color=#ff8080>");
+            sb.Append($"{mat.name} : {owned} / {need}");
+            sb.Append("</color>\n");
+            // sb.Append($"보유: {owned}</color>");
+            // sb.Append(" / ");
+            // sb.Append("<color=#a0a0a0>");
+            // sb.Append($"소모: {need}");
+            // sb.Append("</color>");
+            // sb.Append(")\n");
         }
+
         return sb.ToString();
     }
+
 
     public void Toggle()
     {

--- a/ReBloom/Assets/Scripts/CutScene/CutSceneManager.cs
+++ b/ReBloom/Assets/Scripts/CutScene/CutSceneManager.cs
@@ -15,6 +15,7 @@ public class CutSceneManager : MonoBehaviour
     [SerializeField] private Image cutSceneImage;
     [SerializeField] private Image backgroundImage;
     [SerializeField] private CanvasGroup cutSceneGroup;
+    [SerializeField] private GameObject skipHoldUI;
 
     [Header("Settings")]
     [SerializeField] private int introCutSceneId = 1;
@@ -56,6 +57,8 @@ public class CutSceneManager : MonoBehaviour
         cutSceneCts.Cancel();
     }
 
+    private bool isFirst = true;
+    private string currentImgName = "";
     public async UniTask PlayCutSceneSequenceAsync(int startCutSceneId)
     {
         if (isPlaying)
@@ -78,7 +81,7 @@ public class CutSceneManager : MonoBehaviour
             if (cutSceneGroup != null)
             {
                 cutSceneGroup.gameObject.SetActive(true);
-                //cutSceneGroup.alpha = 0f;
+                cutSceneGroup.alpha = 0f;
             }
 
             await ApplyCutSceneVisualAsync(firstData);
@@ -89,11 +92,37 @@ public class CutSceneManager : MonoBehaviour
             int currentId = startCutSceneId;
 
             while (!token.IsCancellationRequested &&
-                   cutSceneDb.TryGet(currentId, out var data))
+            cutSceneDb.TryGet(currentId, out var data))
             {
+                bool imageChanged = currentImgName != data.ImageName;
+
+                if (!isFirst)
+                {
+                    if (imageChanged)
+                    {
+                        if (dialogueUI != null)
+                            dialogueUI.HideInstant();
+
+                        if (cutSceneGroup != null)
+                            await FadeCanvasGroupAsync(cutSceneGroup, 0f, fadeDuration, token);
+                    }
+                }
+                else
+                {
+                    isFirst = false;
+                }
+
                 await ApplyCutSceneVisualAsync(data);
 
-                await dialogueUI.ShowLineAsync(data.TextKR, textColor: Color.yellow);
+                if (imageChanged && cutSceneGroup != null)
+                    await FadeCanvasGroupAsync(cutSceneGroup, 1f, fadeDuration, token);
+
+                currentImgName = data.ImageName;
+
+                await UniTask.Delay(TimeSpan.FromSeconds(0.2f), cancellationToken: token);
+
+                if (dialogueUI != null)
+                    await dialogueUI.ShowLineAsync(data.TextKR);
 
                 if (token.IsCancellationRequested)
                     break;
@@ -116,6 +145,9 @@ public class CutSceneManager : MonoBehaviour
 
             if (backgroundImage != null)
                 backgroundImage.gameObject.SetActive(false);
+
+            if (skipHoldUI != null)
+                skipHoldUI.SetActive(false);
 
             // if (cutSceneGroup != null)
             // {

--- a/ReBloom/Assets/Scripts/DialogueUI.cs
+++ b/ReBloom/Assets/Scripts/DialogueUI.cs
@@ -11,6 +11,9 @@ public class DialogueUI : UIBase
     [SerializeField] private Image backgroundImage;
     [SerializeField] private float typeSpeed = 40f; // 글자/초
 
+    [Header("Fade Settings")]
+    [SerializeField] private float fadeDuration = 0.25f; // 페이드 인/아웃 시간(초)
+
     private bool nextRequested;
     private CanvasGroup canvasGroup;
 
@@ -20,12 +23,41 @@ public class DialogueUI : UIBase
     protected override void Awake()
     {
         base.Awake();
-        canvasGroup = GetComponentInParent<CanvasGroup>();
+        canvasGroup = GetComponent<CanvasGroup>();
         if (backgroundImage != null)
         {
             originalBgColor = backgroundImage.color;
         }
     }
+
+    public async UniTask FadeAsync(float from, float to, float duration)
+    {
+        if (canvasGroup == null || duration <= 0f)
+        {
+            if (canvasGroup != null)
+                canvasGroup.alpha = to;
+            return;
+        }
+
+        var token = this.GetCancellationTokenOnDestroy();
+
+        float t = 0f;
+        canvasGroup.alpha = from;
+
+        while (t < duration)
+        {
+            if (token.IsCancellationRequested)
+                return;
+
+            t += Time.deltaTime;
+            float lerp = Mathf.Clamp01(t / duration);
+            canvasGroup.alpha = Mathf.Lerp(from, to, lerp);
+            await UniTask.Yield(PlayerLoopTiming.Update, token);
+        }
+
+        canvasGroup.alpha = to;
+    }
+
 
     public void OnNextInput(InputAction.CallbackContext ctx)
     {
@@ -34,10 +66,45 @@ public class DialogueUI : UIBase
         nextRequested = true;
     }
 
+    public override void Hide()
+    {
+        if (canvasGroup != null)
+        {
+            FadeAsync(canvasGroup.alpha, 0f, fadeDuration)
+                .ContinueWith(() => base.Hide())
+                .Forget();
+        }
+        else
+        {
+            base.Hide();
+        }
+    }
+
     public override void Show()
     {
         base.Show();
-        if (canvasGroup != null) canvasGroup.alpha = 1f;
+        if (canvasGroup != null)
+        {
+            canvasGroup.alpha = 1f;
+        }
+        // if (canvasGroup != null) {
+        //     canvasGroup.alpha = 0f;
+        //     FadeAsync(0f, 1f, fadeDuration).Forget();
+        // }
+    }
+
+    public void HideInstant()
+    {
+        if (messageText != null)
+            messageText.text = string.Empty;
+
+        if (characterImage != null)
+            characterImage.gameObject.SetActive(false);
+
+        if (canvasGroup != null)
+            canvasGroup.alpha = 0f;
+
+        base.Hide();
     }
 
     public async UniTask ShowLineAsync(

--- a/ReBloom/Assets/Scripts/Inventory/3. UI/Game/GameInventoryUI.cs
+++ b/ReBloom/Assets/Scripts/Inventory/3. UI/Game/GameInventoryUI.cs
@@ -59,7 +59,6 @@ public class GameInventoryUI : UIBase
     #region Unity 생명주기
     protected override void Awake()
     {
-        base.Awake();
         InitializeTabButtons();
         questUI = FindFirstObjectByType<QuestUI>();
 
@@ -87,6 +86,7 @@ public class GameInventoryUI : UIBase
         inventoryData.OnInventoryChanged += RefreshUI;
         DragDropManager.OnDragFeedback += HandleDragFeedback;
         DragDropManager.OnDragFeedback += HandleTrashFeedback;
+        base.Awake();
         ////// 초기화
         //inventoryData.Initialize();
         //CreateEmptySlots();


### PR DESCRIPTION
## 요약
<!-- 이 PR이 왜 생겼는지 한두 줄로 -->
- 크래프팅 UI 개선 (표시 형식 변경 및 보유 수량 표시, 색상으로도 표시)
- 컷씬 개선 (페이드인아웃 추가 및 텍스트 색상 변경)

## 변경 내용
<!-- 코드, 에셋, 테이블 단위로 적기 -->
- 위와 동일
- 
- 

## Unity / 데이터 변경
<!-- SO, Addressable, CSV, Prefab 등 바뀌면 꼭 적기 -->
- [ ] ScriptableObject 변경 있음
- [ ] Prefab / Scene 변경 있음
- [ ] 데이터 테이블 변경 있음
설명:

## 테스트
<!-- 실제로 돌려본 걸 체크 -->
- [x] Unity Editor 플레이 확인
- [ ] 빌드 확인 (플랫폼: )
- [x] 기존 기능에 이상 없음
- [ ] 멀티/씬 전환 시 문제 없음

## 스크린샷 / 영상 (선택)
<!-- UI, 이펙트, 애니메이션 있으면 첨부 -->
-

## 기타 참고
<!-- 기획서/노션/Linear 코멘트 중 리뷰어가 보면 좋은 거 -->
-
